### PR TITLE
Bugfix if a training line contains a comment

### DIFF
--- a/tensorflow_ranking/examples/tf_ranking_libsvm.py
+++ b/tensorflow_ranking/examples/tf_ranking_libsvm.py
@@ -118,7 +118,7 @@ def load_libsvm_data(path, list_size):
 
   def _parse_line(line):
     """Parses a single line in LibSVM format."""
-    tokens = line.split()
+    tokens = line.split("#")[0].split()
     assert len(tokens) >= 2, "Ill-formatted line: {}".format(line)
     label = float(tokens[0])
     qid = tokens[1]


### PR DESCRIPTION
Hello,

First, thanks for this amazing LTR lib. I'm proposing this bugfix because the example script does not works if the train/eval/test files contains a comment at the end of at least one of their line.