### PR TITLE
Added `params` to `transform_fn`

### DIFF
--- a/tensorflow_ranking/python/model.py
+++ b/tensorflow_ranking/python/model.py
@@ -46,6 +46,7 @@ class _RankingModel(object):
           `features`: A dict of Tensors or SparseTensors that contains the raw
             features from an input_fn.
           `mode`: Optional. See estimator `ModeKeys`.
+          `params`: Optional. See tf.estimator model_fn. Hyperparameters for the model.
         * Returns:
           `context_features`: A dict of `Tensor`s with shape [batch_size, ...]
           `example_features`: A dict of `Tensor`s with shape [batch_size,
@@ -56,11 +57,15 @@ class _RankingModel(object):
     else:
       self._transform_fn = transform_fn
 
-  def _call_transform_fn(self, features, mode):
+  def _call_transform_fn(self, features, mode, params):
     """Calls transform_fn and returns dense Tensors."""
     transform_fn_args = function_utils.fn_args(self._transform_fn)
-    if 'mode' in transform_fn_args:
+    if 'mode' in transform_fn_args and 'params' in transform_fn_args:
+      return self._transform_fn(features, mode=mode, params=params)
+    elif 'mode' in transform_fn_args:
       return self._transform_fn(features, mode=mode)
+    elif 'params' in transform_fn_args:
+      return self._transform_fn(features, params=params)
     else:
       return self._transform_fn(features)
 
@@ -89,7 +94,7 @@ class _RankingModel(object):
     """
     with tf.compat.v1.name_scope('transform'):
       context_features, example_features = self._call_transform_fn(
-          features, mode)
+          features, mode, params)
       # Check feature tensor shape.
       for name, value in six.iteritems(example_features):
         tensor_shape = tf.convert_to_tensor(value).shape


### PR DESCRIPTION
It would be nice to have the hyper `params` passed to the `transform_fn` just like the `group_score_fn` so you can do something like this:

```python
def example_feature_columns(params):
    rest_id = categorical_column_with_identity(key='rid', num_buckets=item_buckets)
    rest_emb = embedding_column(rest_id, params.K)
    return {"rid": rest_emb}

def make_transform_fn():
    def _transform_fn(features, mode, params):
        """Defines transform_fn."""
        example_name = next(six.iterkeys(example_feature_columns(params)))
        input_size = tf.shape(input=features[example_name])[1]
        context_features, example_features = tfr.feature.encode_listwise_features(
            features=features,
            input_size=input_size,
            context_feature_columns=context_feature_columns(),
            example_feature_columns=example_feature_columns(params),
            mode=mode,
            scope="transform_layer")

        return context_features, example_features
    return _transform_fn
```

See how I added `params` to the signature of `_transform_fn` so now it can accept hyper params like the `group_score_fn`?

The use case for this is the common one where the embedding dimensions are a hyper parameter. 

https://github.com/tensorflow/ranking/issues/31#issuecomment-511071030