### PR TITLE
Argument types mismatch in tf.where

### DIFF
--- a/tensorflow_ranking/python/data.py
+++ b/tensorflow_ranking/python/data.py
@@ -335,7 +335,7 @@ class _SequenceExampleParser(_RankingDataParser):
           tf.shape(tensor))
       tensor = tf.where(
           tf.less(rank, tf.cast(size, tf.int32)), tensor,
-          tf.fill(tf.shape(tensor), v))
+          tf.fill(tf.shape(tensor), tf.cast(v, tensor.dtype)))
       examples[k] = tensor
 
     list_size_arg = list_size


### PR DESCRIPTION
In my case, the datatype of `tensor` is tf.int64, but the datatype of `v` (which is created by `_get_scalar_default_value` is tf.int32. I think it is better to cast `v` to the datatype of `tensor` explicitly.