### PR TITLE
[Fix #116] fix padding_values not initialized when using FixedLenSequ…

### DIFF
--- a/tensorflow_ranking/python/data.py
+++ b/tensorflow_ranking/python/data.py
@@ -309,12 +309,14 @@ class _SequenceExampleParser(_RankingDataParser):
     padding_values = {}
     non_trivial_padding_values = {}
     for k, s in six.iteritems(example_feature_spec):
+      if isinstance(s, tf.io.FixedLenFeature
+                   ) or isinstance(s, tf.io.FixedLenSequenceFeature):
+        scalar = _get_scalar_default_value(s.dtype, s.default_value)
+        padding_values[k] = scalar
       if not isinstance(s, tf.io.FixedLenFeature):
         continue
       fixed_len_sequence_features[k] = tf.io.FixedLenSequenceFeature(
           s.shape, s.dtype, allow_missing=True)
-      scalar = _get_scalar_default_value(s.dtype, s.default_value)
-      padding_values[k] = scalar
       if scalar:
         non_trivial_padding_values[k] = scalar
 


### PR DESCRIPTION
…enceFeature

When I use `tfr.data.read_batched_sequence_example_dataset` with example_feature_spec containing `tf.FixedLenSequenceFeature`, it raises a KeyError.

In `_SequenceExampleParser.parse`,  it convert `FixedLenFeature` to `FixedLenSequenceFeature` and setting dict `padding_values` at the same time.

But when I pass FixedLenSequenceFeature directly, `padding_values` is not set, which remains empty. And in the following code calling `pad_fn` it raises KeyError.

Changing `FixedLenSequenceFeature ` to `FixedLenFeature ` is OK, but I think it's counter-intuitive. It should be compatible with `FixedLenSequenceFeature ` .