### PR TITLE
Fix typo in the full name of arp metric

### DIFF
--- a/tensorflow_ranking/python/metrics.py
+++ b/tensorflow_ranking/python/metrics.py
@@ -40,7 +40,7 @@ class RankingMetricKey(object):
   # Mean Receiprocal Rank. For binary relevance.
   MRR = 'mrr'
 
-  # Average Relvance Position.
+  # Average Relevance Position.
   ARP = 'arp'
 
   # Normalized Discounted Culmulative Gain.


### PR DESCRIPTION
Change `Relvance` to `Relevance` of ARP description in ranking metrics.