### PR TITLE
Make predict_input_fn compatible with TF 2.0

### DIFF
--- a/tensorflow_ranking/examples/handling_sparse_features.ipynb
+++ b/tensorflow_ranking/examples/handling_sparse_features.ipynb
@@ -976,7 +976,7 @@
         "        reader=tf.data.TFRecordDataset,\n",
         "        shuffle=False,\n",
         "        num_epochs=1)\n",
-        "  features = tf.data.make_one_shot_iterator(dataset).get_next()\n",
+        "  features = tf.compat.v1.data.make_one_shot_iterator(dataset).get_next()\n",
         "  return features"
       ]
     },


### PR DESCRIPTION
`predict_input_fn` in handling_sparse_features.ipynb not work in TF 2.0

Report attribute error as :
AttributeError: 'BatchDataset' object has no attribute 'make_one_shot_iterator'