### PR TITLE
Improve variable naming in metrics test

### DIFF
--- a/tensorflow_ranking/python/metrics_test.py
+++ b/tensorflow_ranking/python/metrics_test.py
@@ -47,14 +47,17 @@ def _dcg(label,
 
 def _ap(relevances, scores, topn=None):
   """Returns the average precision (AP) of a single ranked list.
+
   The implementation here is copied from Equation (1.7) in
   Liu, T-Y "Learning to Rank for Information Retrieval" found at
   https://www.nowpublishers.com/article/DownloadSummary/INR-016
+
   Args:
     relevances: A `list` of document relevances, which are binary.
     scores: A `list` of document scores.
     topn: An `integer` specifying the number of items to be considered in the
       average precision computation.
+
   Returns:
     The MAP of the list as a float computed using the formula
     sum([P@k * rel for k, rel in enumerate(relevance)]) / sum(relevance)

--- a/tensorflow_ranking/python/metrics_test.py
+++ b/tensorflow_ranking/python/metrics_test.py
@@ -47,17 +47,14 @@ def _dcg(label,
 
 def _ap(relevances, scores, topn=None):
   """Returns the average precision (AP) of a single ranked list.
-
   The implementation here is copied from Equation (1.7) in
   Liu, T-Y "Learning to Rank for Information Retrieval" found at
   https://www.nowpublishers.com/article/DownloadSummary/INR-016
-
   Args:
     relevances: A `list` of document relevances, which are binary.
     scores: A `list` of document scores.
     topn: An `integer` specifying the number of items to be considered in the
       average precision computation.
-
   Returns:
     The MAP of the list as a float computed using the formula
     sum([P@k * rel for k, rel in enumerate(relevance)]) / sum(relevance)
@@ -70,16 +67,14 @@ def _ap(relevances, scores, topn=None):
   num_docs = len(relevances)
   if isinstance(topn, int) and topn > 0:
     num_docs = min(num_docs, topn)
-  inds = argsort(scores)[:num_docs]
-  ranked_rels = [1. * relevances[i] for i in inds]
-  prec = {}
-  l = {}
+  indices = argsort(scores)[:num_docs]
+  ranked_relevances = [1. * relevances[i] for i in indices]
+  precision = {}
   for k in range(1, num_docs+1):
-    prec[k] = sum(ranked_rels[:k]) / k
-    l[k] = ranked_rels[k-1]
-  num_rel = sum(l.values())
-  ap = sum(prec[k] * l[k] for k in prec) / num_rel if num_rel else 0
-  return ap
+    precision[k] = sum(ranked_relevances[:k]) / k
+  num_rel = sum(ranked_relevances[:num_docs])
+  average_precision = sum(precision[k] * ranked_relevances[k-1] for k in precision) / num_rel if num_rel else 0
+  return average_precision
 
 
 def _label_boost(boost_form, label):


### PR DESCRIPTION
Improve several variables naming.
Remove variable `l` which has no meaning and seems to be redundant.