### PR TITLE
Added Parts of GAP metric for MultiLevel LTR

### DIFF
--- a/tensorflow_ranking/python/metrics_impl.py
+++ b/tensorflow_ranking/python/metrics_impl.py
@@ -428,3 +428,17 @@ class OPAMetric(_RankingMetric):
             weights, 2) * tf.cast(
                 valid_pair, dtype=tf.float32)
     return correct_pairs, pair_weights
+
+class GlobalAveragePrecisionMetric(_RankingMetric):
+  """Implements Global Average Precesion (GAP)."""
+  def __init__(self, name):
+    """Constructor."""
+    self._name = name
+  
+  @property
+  def name(self):
+    """The metric name."""
+    return self._name
+
+  def compute(self, labels, predictions, weights):
+    pass

--- a/tensorflow_ranking/python/metrics_test.py
+++ b/tensorflow_ranking/python/metrics_test.py
@@ -817,6 +817,25 @@ class MetricsTest(tf.test.TestCase):
                   key, labels, scores, weights, 2, name=key))
           self.assertGreater(value, 0.)
 
+  def test_global_average_precision(self):
+    with tf.Graph().as_default():
+      scores = [[1., 3., 2.], [1., 2., 3.]]
+      # Note that scores are ranked in descending order, so the ranks are
+      # [[3, 1, 2], [3, 2, 1]]
+      labels = [[0., 0., 1.], [0., 1., 2.]]
+      rels = [[0, 0, 1], [0, 1, 1]]
+      m = metrics_lib.global_average_precision
+      # self._check_metrics([
+      #     (m([labels[0]], [scores[0]]), _ap(rels[0], scores[0])),
+      #     (m([labels[0]], [scores[0]], topn=1), _ap(rels[0], scores[0],
+      #                                               topn=1)),
+      #     (m([labels[0]], [scores[0]], topn=2), _ap(rels[0], scores[0],
+      #                                               topn=2)),
+      #     (m(labels,
+      #        scores), sum(_ap(rels[i], scores[i]) for i in range(2)) / 2.),
+      #     (m(labels, scores, topn=1),
+      #      sum(_ap(rels[i], scores[i], topn=1) for i in range(2)) / 2.),
+      # ])
 
 if __name__ == '__main__':
   tf.compat.v1.enable_v2_behavior()


### PR DESCRIPTION
### Adding Global Average Precision (GAP) to TF-ranking supported Ranking metrics

## I have added snippets of code to the metrics files ( **metrics.py**,  **metrics_impl.py**, and **metrics_tets.py**
The GAP metric is important when evaluating ranking models with multi-level relevance judgement for example (0-5)  levels.