### PR TITLE
passing parameters into Dense Layer instead of into tf.keras.Sequential.add

### DIFF
--- a/tensorflow_ranking/python/keras/layers.py
+++ b/tensorflow_ranking/python/keras/layers.py
@@ -68,7 +68,7 @@ def create_tower(hidden_layer_dims: List[int],
   if input_batch_norm:
     model.add(tf.keras.layers.BatchNormalization(momentum=batch_norm_moment))
   for layer_width in hidden_layer_dims:
-    model.add(tf.keras.layers.Dense(units=layer_width,**kwargs))
+    model.add(tf.keras.layers.Dense(units=layer_width, **kwargs))
     if use_batch_norm:
       model.add(tf.keras.layers.BatchNormalization(momentum=batch_norm_moment))
     model.add(tf.keras.layers.Activation(activation=activation))

--- a/tensorflow_ranking/python/keras/layers.py
+++ b/tensorflow_ranking/python/keras/layers.py
@@ -68,13 +68,13 @@ def create_tower(hidden_layer_dims: List[int],
   if input_batch_norm:
     model.add(tf.keras.layers.BatchNormalization(momentum=batch_norm_moment))
   for layer_width in hidden_layer_dims:
-    model.add(tf.keras.layers.Dense(units=layer_width), **kwargs)
+    model.add(tf.keras.layers.Dense(units=layer_width,**kwargs))
     if use_batch_norm:
       model.add(tf.keras.layers.BatchNormalization(momentum=batch_norm_moment))
     model.add(tf.keras.layers.Activation(activation=activation))
     if dropout:
       model.add(tf.keras.layers.Dropout(rate=dropout))
-  model.add(tf.keras.layers.Dense(units=output_units), **kwargs)
+  model.add(tf.keras.layers.Dense(units=output_units, **kwargs))
   return model
 
 


### PR DESCRIPTION
In create_tower function, the dictionary parameters should be passed into tf.keras.layers.Dense instead of into tf.keras.Sequential.add function. The only parameter tf.keras.Sequential.add takes is a LayerObject.  The current code would result error like

TypeError: add() got an unexpected keyword argument 'kernel_regularizer'

when a key value pair like "kernel_regularizer": tf.keras.regularizers.l2 is passed.
