### PR TITLE
Fixed math expressions in keras losses documentation

### DIFF
--- a/docs/api_docs/python/tfr/keras/losses/SigmoidCrossEntropyLoss.md
+++ b/docs/api_docs/python/tfr/keras/losses/SigmoidCrossEntropyLoss.md
@@ -68,9 +68,7 @@ model.compile(optimizer='sgd',
 #### Definition:
 
 $$
-\mathcal{L}(\{y\}, \{s\}) = - \sum_{i}
-y_i \log(\text{sigmoid}(s_i))
-+ (1 - y_i) \log(1 - \text{sigmoid}(s_i))
+\mathcal{L}(\{y\}, \{s\}) = - \sum_{i} y_i \log(\text{sigmoid}(s_i))+ (1 - y_i) \log(1 - \text{sigmoid}(s_i))
 $$
 
 <!-- Tabular view -->

--- a/docs/api_docs/python/tfr/keras/losses/SoftmaxLoss.md
+++ b/docs/api_docs/python/tfr/keras/losses/SoftmaxLoss.md
@@ -67,8 +67,7 @@ model.compile(optimizer='sgd', loss=tfr.keras.losses.SoftmaxLoss())
 #### Definition:
 
 $$
-\mathcal{L}(\{y\}, \{s\}) =
-- \sum_i y_i \cdot \log\left(\frac{exp(s_i)}{\sum_j exp(s_j)}\right)
+\mathcal{L}(\{y\}, \{s\}) =- \sum_i y_i \cdot \log\left(\frac{exp(s_i)}{\sum_j exp(s_j)}\right)
 $$
 
 <!-- Tabular view -->


### PR DESCRIPTION
The math expression did not show up correctly and I fixed that in SoftmaxLoss and SigmoidCrossEntropyLoss