### PR TITLE
Fixed math expression for `UniqueSoftmaxLoss`

### DIFF
--- a/docs/api_docs/python/tfr/keras/losses/UniqueSoftmaxLoss.md
+++ b/docs/api_docs/python/tfr/keras/losses/UniqueSoftmaxLoss.md
@@ -71,9 +71,7 @@ model.compile(optimizer='sgd', loss=tfr.keras.losses.UniqueSoftmaxLoss())
 #### Definition:
 
 $$
-\mathcal{L}(\{y\}, \{s\}) =
-- \sum_i (2^{y_i} - 1) \cdot
-\log\left(\frac{\exp(s_i)}{\sum_j I_{y_i > y_j} \exp(s_j) + \exp(s_i)}\right)
+\mathcal{L}(\{y\}, \{s\}) =- \sum_i (2^{y_i} - 1) \cdot\log\left(\frac{\exp(s_i)}{\sum_j I_{y_i > y_j} \exp(s_j) + \exp(s_i)}\right)
 $$
 
 #### References:

--- a/tensorflow_ranking/python/keras/losses.py
+++ b/tensorflow_ranking/python/keras/losses.py
@@ -694,8 +694,7 @@ class UniqueSoftmaxLoss(_ListwiseLoss):
   Definition:
 
   $$
-  \mathcal{L}(\{y\}, \{s\}) =
-  - \sum_i (2^{y_i} - 1) \cdot
+  \mathcal{L}(\{y\}, \{s\}) =- \sum_i (2^{y_i} - 1) \cdot
   \log\left(\frac{\exp(s_i)}{\sum_j I_{y_i > y_j} \exp(s_j) + \exp(s_i)}\right)
   $$
 


### PR DESCRIPTION
The math expression did not show up correctly and I fixed that in UniqueSoftmaxLoss