### PR TITLE
Updated quickstart tutorial with new apis

### DIFF
--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -162,11 +162,11 @@
         "movies = movies.map(lambda x: x[\"movie_title\"])\n",
         "users = ratings.map(lambda x: x[\"user_id\"])\n",
         "\n",
-        "user_ids_vocabulary = tf.keras.layers.experimental.preprocessing.StringLookup(\n",
+        "user_ids_vocabulary = tf.keras.layers.StringLookup(\n",
         "    mask_token=None)\n",
         "user_ids_vocabulary.adapt(users.batch(1000))\n",
         "\n",
-        "movie_titles_vocabulary = tf.keras.layers.experimental.preprocessing.StringLookup(\n",
+        "movie_titles_vocabulary = tf.keras.layers.StringLookup(\n",
         "    mask_token=None)\n",
         "movie_titles_vocabulary.adapt(movies.batch(1000))"
       ]


### PR DESCRIPTION
Updated quickstart tutorial with new apis
Old api - tf.keras.layers.experimental.preprocessing.StringLookup 
New api -  tf.keras.layers.StringLookup
Attached [Old](https://colab.sandbox.google.com/github/tensorflow/ranking/blob/master/docs/tutorials/quickstart.ipynb#scrollTo=9I1VTEjHzpfX) and [new](https://colab.sandbox.google.com/gist/mohantym/c50fbb9c662018c9216f0140cc409cc7/quickstart.ipynb#scrollTo=9I1VTEjHzpfX) gist for reference.