### PR TITLE
Pin protobuf version to 3.20.3 to fix an import error

### DIFF
--- a/docs/tutorials/ranking_dnn_distributed.ipynb
+++ b/docs/tutorials/ranking_dnn_distributed.ipynb
@@ -104,7 +104,8 @@
       "outputs": [],
       "source": [
         "!pip install -q tensorflow-ranking tensorflow-serving-api\n",
-        "!pip install -U \"tensorflow-text==2.11.*\""
+        "!pip install -U \"tensorflow-text==2.11.*\"\n",
+        "!pip install -q protobuf==3.20.3"
       ]
     },
     {


### PR DESCRIPTION
As title. This fixes the following:
```
ImportError                               Traceback (most recent call last)
[<ipython-input-1-84f0d6543138>](https://localhost:8080/#) in <cell line: 6>()
      4 import tensorflow_ranking as tfr
      5 import tensorflow_text as tf_text
----> 6 from tensorflow_serving.apis import input_pb2
      7 from google.protobuf import text_format

[/usr/local/lib/python3.10/dist-packages/tensorflow_serving/apis/input_pb2.py](https://localhost:8080/#) in <module>
      3 # source: tensorflow_serving/apis/input.proto
      4 """Generated protocol buffer code."""
----> 5 from google.protobuf.internal import builder as _builder
      6 from google.protobuf import descriptor as _descriptor
      7 from google.protobuf import descriptor_pool as _descriptor_pool

ImportError: cannot import name 'builder' from 'google.protobuf.internal' (/usr/local/lib/python3.10/dist-packages/google/protobuf/internal/__init__.py)```